### PR TITLE
Add GitHub.copilot-chat to devcontainer extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,8 +15,8 @@
     "customizations": {
         "vscode": {
         "extensions": [
-            "github.copilot", // GitHub Copilot + Copilot Chat
-            "github.copilot-chat",
+            "github.copilot", // GitHub Copilot
+            "github.copilot-chat", // Copilot Chat
             "markdown-lint.markdownlinter",
             "ms-python.python", // Python extension
             "ms-python.vscode-pylance", // Pylance extension for Python

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
         "vscode": {
         "extensions": [
             "github.copilot", // GitHub Copilot + Copilot Chat
+            "github.copilot-chat",
             "markdown-lint.markdownlinter",
             "ms-python.python", // Python extension
             "ms-python.vscode-pylance", // Pylance extension for Python


### PR DESCRIPTION
Adds GitHub.copilot-chat extension to the devcontainer configuration to enable Copilot Chat in the development environment.