### PR TITLE
Fix Step 1 Codespaces onboarding instructions

### DIFF
--- a/.github/steps/1-preparing.md
+++ b/.github/steps/1-preparing.md
@@ -12,13 +12,13 @@ In this exercise, you will build a **modern multi-tier application** for OctoFit
 
 To work on this exercise, first create a Codespace for **your copy** of the repository.
 
-1. Right-click the button below and open the **Create Codespace** page in a new tab. Use the default configuration.
+1. Open the button below in a new tab to launch the **Create Codespace** page. Use the default configuration.
 
    [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/{{full_repo_name}}?quickstart=1)
 
 1. Confirm the **Repository** field is your copy of the exercise, not the original, then click the green **Create Codespace** button.
-   - ✅ Your copy: `/{{full_repo_name}}`
-   - ❌ Original: `/skills/build-applications-w-copilot-agent-mode`
+   - ✅ Your copy: `{{full_repo_name}}`
+   - ❌ Original: `skills/build-applications-w-copilot-agent-mode`
 
 1. Wait for Visual Studio Code to load in your browser and extensions to finish installing.
 

--- a/.github/steps/1-preparing.md
+++ b/.github/steps/1-preparing.md
@@ -8,9 +8,19 @@ In this exercise, you will build a **modern multi-tier application** for OctoFit
 - **Logic tier:** Node.js + Express + TypeScript
 - **Data tier:** MongoDB
 
-### :keyboard: Activity: Create and publish your working branch
+### :keyboard: Activity: Set up Codespaces and publish your working branch
 
-1. Open your Codespace for your repository copy.
+To work on this exercise, first create a Codespace for **your copy** of the repository.
+
+1. Right-click the button below and open the **Create Codespace** page in a new tab. Use the default configuration.
+
+   [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/{{full_repo_name}}?quickstart=1)
+
+1. Confirm the **Repository** field is your copy of the exercise, not the original, then click the green **Create Codespace** button.
+   - ✅ Your copy: `/{{full_repo_name}}`
+   - ❌ Original: `/skills/build-applications-w-copilot-agent-mode`
+
+1. Wait for Visual Studio Code to load in your browser and extensions to finish installing.
 
 1. Open Copilot Chat and switch to **Agent** mode.
 


### PR DESCRIPTION
## Why
Step 1 was missing a direct Codespaces entry point, which can block learners before they reach the branch creation activity.

## What changed
- Updated `.github/steps/1-preparing.md` to include an "Open in GitHub Codespaces" badge linked to `https://codespaces.new/{{full_repo_name}}?quickstart=1`.
- Added explicit guidance to confirm the repository is the learner's copy, not the original `skills/build-applications-w-copilot-agent-mode` repo.
- Added a short wait-for-setup instruction before moving into Copilot Agent mode.
- Kept the existing `build-octofit-app` branch creation flow intact.

## Notes for reviewers
This is a docs-only fix scoped to Step 1 onboarding behavior.