### PR TITLE
Retry Step 1 workflow activation

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -65,6 +65,14 @@ jobs:
 
       - name: Enable next step workflow
         run: |
-          gh workflow enable "Step 1"
+          for attempt in 1 2 3 4 5 6; do
+            if gh workflow enable "Step 1"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 6 ]; then
+              sleep 5
+            fi
+          done
+          exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
New repositories can briefly fail to resolve the Step 1 workflow while GitHub Actions is registering workflows from the template. This leaves the exercise initialized but unable to progress.

Retry the existing `gh workflow enable "Step 1"` command inline up to six times with a five-second delay. This preserves the current exercise-toolkit workflow model and fails clearly if registration does not complete.